### PR TITLE
Fix actions

### DIFF
--- a/.github/workflows/macOS.yml
+++ b/.github/workflows/macOS.yml
@@ -16,9 +16,9 @@ jobs:
     runs-on: macos-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Setup Swift
-      uses: fwal/setup-swift@v1.14.0
+      uses: swift-actions/setup-swift@v2
     - name: Build
       run: swift build -v
     - name: Run tests

--- a/.github/workflows/ubuntu.yml
+++ b/.github/workflows/ubuntu.yml
@@ -16,9 +16,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Setup Swift
-      uses: fwal/setup-swift@v1.14.0
+      uses: swift-actions/setup-swift@v2
     - name: Build
       run: swift build -v
     - name: Run tests


### PR DESCRIPTION
Tests are still passing on latest OSs and swift versions, but there is an issue with the action build. This fixes it by moving to [swift-actions/setup-swift](https://github.com/swift-actions/setup-swift)